### PR TITLE
remove hyperlinks from Background tab content

### DIFF
--- a/vtech/templates/propStatement-adviseeIn.ftl
+++ b/vtech/templates/propStatement-adviseeIn.ftl
@@ -1,0 +1,33 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- Custom object property statement view for faux property "advisee of". See the PropertyConfig.n3 file for details.
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+<#import "lib-datetime.ftl" as dt>
+<@showAdviseeIn statement />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showAdviseeIn statement>
+    <#-- It's possible that adviseeIn relationships were created before the custom form and only have
+         an rdfs:label. So check to see if there's an advisor first. If not, just display the label.  -->
+    <#local linkedIndividual>
+        <#if statement.advisor??>
+            <#if statement.degreeLabel?? || statement.dateTimeStart?? || statement.dateTimeEnd?? >
+                <span>${statement.advisorLabel!}</span>,
+            <#else>
+                <span>${statement.advisorLabel!}</span>
+            </#if>
+            <#if statement.degreeLabel??>
+                ${statement.degreeAbbr!statement.degreeLabel!} 
+                <#if statement.dateTimeStart?? || statement.dateTimeEnd?? >&nbsp;${i18n().candidacy},<#else>&nbsp;${i18n().candidacy}</#if>
+            </#if>
+        <#elseif statement.advisingRelLabel??>
+            <span>${statement.advisingRelLabel!statement.localName}</span>
+        </#if>
+    </#local>
+
+    ${linkedIndividual}    <@dt.yearIntervalSpan "${statement.dateTimeStart!}" "${statement.dateTimeEnd!}" /> 
+ </#macro>

--- a/vtech/templates/propStatement-awardOrHonor.ftl
+++ b/vtech/templates/propStatement-awardOrHonor.ftl
@@ -1,0 +1,40 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- Custom object property statement view for faux property "awards and honors". See the PropertyConfig.n3 file for details.
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+<#import "lib-sequence.ftl" as s>
+<#import "lib-datetime.ftl" as dt>
+<@showAward statement />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showAward statement>
+ 
+    <#local linkedIndividual>
+        <#if statement.award??>
+            <span>${statement.awardLabel!}</span>
+        <#else>
+            <span>${statement.receiptLabel!}</span>
+        </#if>
+    </#local>
+
+    <#local dateTimeVal>
+        <#if statement.dateTime??>
+            <@dt.yearSpan statement.dateTime! /> 
+        <#else>
+            <@dt.yearIntervalSpan "${statement.dateTimeStart!}" "${statement.dateTimeEnd!}" />
+        </#if>
+    </#local>
+
+    <#local assignedByOrg>
+        <#if statement.assignedBy?has_content && statement.assignedByLabel?has_content>
+             ${i18n().conferred_by} <span>${statement.assignedByLabel}</span>
+        </#if>
+    </#local>
+
+    <@s.join [ linkedIndividual, assignedByOrg!,  dateTimeVal! ] />
+
+ </#macro>

--- a/vtech/templates/propStatement-default.ftl
+++ b/vtech/templates/propStatement-default.ftl
@@ -1,0 +1,21 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- VIVO-specific default object property statement template. 
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+-->
+
+<#import "lib-meta-tags.ftl" as lmt>
+
+<@showStatement statement />
+
+<#macro showStatement statement>
+    <#-- The query retrieves a type only for Persons. Post-processing will remove all but one. --> 
+  	<#if statement.subclass??>
+		<span>${statement.label!statement.localName!}</span>
+	<#else>
+    	<span>${statement.label!statement.localName!}</span>&nbsp; ${statement.title!statement.type!}
+	</#if>
+	<@lmt.addCitationMetaTag uri=(statement.specificObjectType) content=(statement.label!) />
+</#macro>

--- a/vtech/templates/propStatement-educationalTraining.ftl
+++ b/vtech/templates/propStatement-educationalTraining.ftl
@@ -1,0 +1,43 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- Custom object property statement view for faux property "education and training". See the PropertyConfig.n3 file for details.
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+
+<#import "lib-sequence.ftl" as s>
+<#import "lib-datetime.ftl" as dt>
+<#-- Coming from propDelete, individual is not defined, but we are editing. -->
+<@showEducationalTraining statement=statement editable=(!individual?? || individual.editable) />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showEducationalTraining statement editable>
+
+    <#local degree>
+        <#if statement.degreeName??>
+            ${statement.degreeAbbr!statement.degreeName} 
+            <#if statement.majorField??> ${i18n().in} ${statement.majorField}</#if>
+        <#elseif statement.typeName??>
+            ${statement.typeName!}
+        </#if>
+    </#local>
+    
+    <#local linkedIndividual>
+        <#if statement.org??>
+			<#assign schemaType = "http://schema.org/Organization" />
+			<#assign subclass = statement.subclass!"" />
+			<#if subclass?contains("Educational") >
+				<#assign schemaType = "http://schema.org/CollegeOrUniversity" />
+			</#if>
+			<span itemscope itemtype="${schemaType}">${statement.orgName}</span>
+        <#elseif editable>
+            <#-- Show the link to the context node only if the user is editing the page. -->
+            <a href="${profileUrl(statement.uri("edTraining"))}" title="${i18n().missing_organization}">${i18n().missing_organization}</a>
+        </#if>
+    </#local>
+
+    <@s.join [ degree, linkedIndividual!, statement.deptOrSchool!, statement.info! ] /> <@dt.yearIntervalSpan "${statement.dateTimeStart!}" "${statement.dateTimeEnd!}" false/> 
+
+</#macro>

--- a/vtech/templates/propStatement-issuedCredential.ftl
+++ b/vtech/templates/propStatement-issuedCredential.ftl
@@ -1,0 +1,35 @@
+<#-- $This file is distributed under the terms of the license in /doc/license.txt$ -->
+
+<#-- Custom object property statement view for http://vivoweb.org/ontology/core#credentialOrHonor. 
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+<#import "lib-sequence.ftl" as s>
+<#import "lib-datetime.ftl" as dt>
+<@showCredential statement />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showCredential statement>
+ 
+    <#local linkedIndividual>
+        <#if statement.credential??>
+            <span>${statement.credentialLabel!statement.issuedCredentialLabel!statement.credentialLocal!}</span>
+        <#else>
+            <span>${statement.issuedCredentialLabel!"${i18n().missing_credential}"}</span>
+        </#if>
+    </#local>
+
+    <#local dateTimeVal>
+        <#if statement.dateTime??>
+            <@dt.yearSpan statement.dateTime! /> 
+        <#else>
+            <@dt.yearIntervalSpan "${statement.dateTimeStart!}" "${statement.dateTimeEnd!}" />
+        </#if>
+    </#local>
+
+
+    <@s.join [ linkedIndividual,  dateTimeVal! ] />
+
+ </#macro>


### PR DESCRIPTION
**Remove hyperlinks from Background tab content.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1606) (:star:)

# What does this Pull Request do? (:star:)
Overrides VIVO templates to remove hyperlinks from the content in the Profile Background tab.

# What's the changes? (:star:)
Overrides:
* vtech/templates/propStatement-adviseeIn.ftl
* vtech/templates/propStatement-awardOrHonor.ftl
* vtech/templates/propStatement-default.ftl
* vtech/templates/propStatement-educationalTraining.ftl
* vtech/templates/propStatement-issuedCredential.ftl

# How should this be tested?

A description of what steps someone could take to:
* Login and create an example user on the `/vivo/siteAdmin` page.
* Go to that user's profile page and click the `Background` tab
* Create content for all of the fields in that tab
* Make sure that there are no hyperlinks in the displayed content

# Additional Notes:
* branch: `LIBTD-1606`

# Interested parties
@yinlinchen 

