### PR TITLE
Exclude classes in Search index for People and Organization class gr…

### DIFF
--- a/rdf/display/everytime/vitroSearchProhibited_Organization.n3
+++ b/rdf/display/everytime/vitroSearchProhibited_Organization.n3
@@ -1,0 +1,57 @@
+# $This file is distributed under the terms of the license in /doc/license.txt$ 
+
+# All instances of a class can be excluded from the search index by adding a 
+# vitroDisplay:excludeClass property between vitroDisplay:SearchIndex and the 
+# URI of the class that you would like to exclude.
+
+# .n3 or .rdf files can be created in this directory to configure the search 
+# exclusions.  Each file must be a valid file in the format specified by its 
+# extension. Each file will be loaded individually and must be a complete 
+# stand alone example of its format.  Each file must contain all the necessary 
+# prefixes, namespaces and preambles required by the format specified by its 
+# extension.  
+
+# If you would like to add classes to the exclusions, add a file to this 
+# directory ending in .n3 with N3 statements similar to this example.
+
+#
+# @prefix owl: <http://www.w3.org/2002/07/owl#> .
+# @prefix vitroDisplay: <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#> .
+# @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+# @prefix example: <http://example/ns/> .
+#
+# vitroDisplay:SearchIndex 
+#    rdf:type owl:Thing ; 
+#    vitroDisplay:excludeClass example:classToExclude ;
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix vitroDisplay: <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix core: <http://vivoweb.org/ontology/core#> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+
+vitroDisplay:SearchIndex
+    rdf:type owl:Thing ; 
+    vitroDisplay:excludeClass core:Association ;
+    vitroDisplay:excludeClass core:Center ;
+    vitroDisplay:excludeClass core:ClinicalOrganization ;
+    vitroDisplay:excludeClass core:College ;
+    vitroDisplay:excludeClass core:Company ;
+    vitroDisplay:excludeClass core:Consortium ;
+    vitroDisplay:excludeClass core:Division ;
+    vitroDisplay:excludeClass core:ExtensionUnit ;
+    vitroDisplay:excludeClass core:Foundation ;
+    vitroDisplay:excludeClass core:FundingOrganization ;
+    vitroDisplay:excludeClass core:GovernmentAgency ;
+    vitroDisplay:excludeClass foaf:Group ;
+    vitroDisplay:excludeClass core:Hospital ;
+    vitroDisplay:excludeClass core:Institute ;
+    vitroDisplay:excludeClass core:Laboratory ;
+    vitroDisplay:excludeClass core:Library ;
+    vitroDisplay:excludeClass core:Museum ;
+    vitroDisplay:excludeClass core:PrivateCompany ;
+    vitroDisplay:excludeClass core:Program ;
+    vitroDisplay:excludeClass core:Publisher ;
+    vitroDisplay:excludeClass core:ResearchOrganization ;
+    vitroDisplay:excludeClass core:School ;
+    vitroDisplay:excludeClass core:StudentOrganization ;
+    vitroDisplay:excludeClass core:University .

--- a/rdf/display/everytime/vitroSearchProhibited_People.n3
+++ b/rdf/display/everytime/vitroSearchProhibited_People.n3
@@ -1,0 +1,40 @@
+# $This file is distributed under the terms of the license in /doc/license.txt$ 
+
+# All instances of a class can be excluded from the search index by adding a 
+# vitroDisplay:excludeClass property between vitroDisplay:SearchIndex and the 
+# URI of the class that you would like to exclude.
+
+# .n3 or .rdf files can be created in this directory to configure the search 
+# exclusions.  Each file must be a valid file in the format specified by its 
+# extension. Each file will be loaded individually and must be a complete 
+# stand alone example of its format.  Each file must contain all the necessary 
+# prefixes, namespaces and preambles required by the format specified by its 
+# extension.  
+
+# If you would like to add classes to the exclusions, add a file to this 
+# directory ending in .n3 with N3 statements similar to this example.
+
+#
+# @prefix owl: <http://www.w3.org/2002/07/owl#> .
+# @prefix vitroDisplay: <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#> .
+# @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+# @prefix example: <http://example/ns/> .
+#
+# vitroDisplay:SearchIndex 
+#    rdf:type owl:Thing ; 
+#    vitroDisplay:excludeClass example:classToExclude ;
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix vitroDisplay: <http://vitro.mannlib.cornell.edu/ontologies/display/1.1#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix core: <http://vivoweb.org/ontology/core#> .
+@prefix foaf:    <http://xmlns.com/foaf/0.1/> .
+
+vitroDisplay:SearchIndex
+    rdf:type owl:Thing ; 
+    vitroDisplay:excludeClass core:EmeritusFaculty ;
+    vitroDisplay:excludeClass core:Student ;
+    vitroDisplay:excludeClass core:Librarian ;
+    vitroDisplay:excludeClass core:EmeritusLibrarian ;
+    vitroDisplay:excludeClass core:NonAcademic ;
+    vitroDisplay:excludeClass core:NonFacultyAcademic ;
+    vitroDisplay:excludeClass core:EmeritusProfessor .


### PR DESCRIPTION
…oups

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1616 and https://webapps.es.vt.edu/jira/browse/LIBTD-1617) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)
https://wiki.duraspace.org/display/VTDA/Excluding+Classes+from+the+Search

# What does this Pull Request do? (:star:)
Excluding classes in search index so that only individuals are 'Faculty member' in 'People' classGroup and 'Academic Department' in 'Organization' classGroup are built into search index.

# What's the changes? (:star:)

* Add two files for "People" and "Organization" classGroups, respectively, to exclude subclasses from search results;
* In the file, add vitroDisplay:excludeClass property between vitroDisplay:SearchIndex and the URI of the class to be excluded.

# How should this be tested?

* Log in as "root", Click on "Site Admin";
* Create an individual as "Non-Academic" and another individual as "Faculty Member";
* Go to "People" menu or Search box, both individuals should be browsable and searchable;
* Go to "Site Admin" and create an individual as "Group" and another individual as "Academic Department";
* Go to "Organizations" menu or Search box, both individuals should be browsable and searchable;
* Put the two n3 files in path: /usr/local/vivo/vdata/rdf/display/everytime/;
* Restart tomcat7;
* Go to "Site Admin", then "Site Maintenance", click on "Rebuild search index", "Rebuild" button until  its completion;
* Go to "People/Organizations" menu or Search box, only the "Faculty Member" and "Academic Department" individuals are browsable and searchable. 

# Additional Notes:

* Branch 1617
* Make sure to follow the testing steps above and put two files in the right path: /usr/local/vivo/vdata/rdf/display/everytime/

# Interested parties
Tag (@yinlinchen ) interested parties

(:star:) Required fields

