### PR TITLE
Remove non-VT author links

### DIFF
--- a/templates/freemarker/body/partials/individual/propStatement-informationResourceInAuthorship.ftl
+++ b/templates/freemarker/body/partials/individual/propStatement-informationResourceInAuthorship.ftl
@@ -1,0 +1,36 @@
+<#-- $This file is distributed under the terms of the license in LICENSE$ -->
+
+<#-- Custom object property statement view for faux property "authors". See the PropertyConfig.n3 file for details.
+    
+     This template must be self-contained and not rely on other variables set for the individual page, because it
+     is also used to generate the property statement during a deletion.  
+ -->
+
+<#import "lib-sequence.ftl" as s>
+<#import "lib-meta-tags.ftl" as lmt>
+
+<@showAuthorship statement />
+
+<#-- Use a macro to keep variable assignments local; otherwise the values carry over to the
+     next statement -->
+<#macro showAuthorship statement>
+    <#if statement.author??>
+        <#if statement.subclass?? && statement.subclass?contains("vcard")>
+                        <#if statement.authorName?replace(" ","")?length == statement.authorName?replace(" ","")?last_index_of(",") + 1 >
+                        ${statement.authorName?replace(",","")}
+                        <#else>
+                                ${statement.authorName}
+                        </#if>
+        <#else>
+                <#if statement.uri("author")?contains("person-") >
+                        ${statement.authorName}
+                <#else>
+                        <a href="${profileUrl(statement.uri("author"))}" title="${i18n().author_name}">${statement.authorName}</a>
+                </#if>
+        </#if>
+                <@lmt.addCitationMetaTag uri="http://vivoweb.org/ontology/core#Authorship" content=statement.authorName />
+    <#else>
+        <#-- This shouldn't happen, but we must provide for it -->
+        <a href="${profileUrl(statement.uri("authorship"))}" title="${i18n().missing_author}">${i18n().missing_author}</a>
+    </#if>
+</#macro>


### PR DESCRIPTION
**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1661) (:star:)

# What does this Pull Request do? (:star:)
Remove non-VT author links and only show VT author link.

# How should this be tested?
Replace propStatement-informationResourceInAuthorship.ftl in tomcat_root/vivo/templates/freemarker/body/partials/individual/

In the publication page, it will show like the attached screenshot. 

# Interested parties
Tag (@whunter ) interested parties

(:star:) Required fields

<img width="1071" alt="screen shot 2018-11-28 at 12 12 22 pm" src="https://user-images.githubusercontent.com/7999195/49169509-e3fb0680-f307-11e8-9186-811f11782888.png">